### PR TITLE
Implement basic settings screen

### DIFF
--- a/tweethistory/lib/features/settings/settings_screen.dart
+++ b/tweethistory/lib/features/settings/settings_screen.dart
@@ -1,16 +1,32 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import '../../providers/theme_provider.dart';
 
-class SettingsScreen extends StatelessWidget {
+class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final themeMode = ref.watch(themeModeProvider);
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: const Text('Settings'),
       ),
-      body: const Center(child: Text('ここに設定画面が表示されます')),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: const Text('Dark Mode'),
+            value: themeMode == ThemeMode.dark,
+            onChanged: (val) {
+              ref.read(themeModeProvider.notifier).setDarkMode(val);
+            },
+          ),
+          const ListTile(
+            title: Text('Import/Export settings (coming soon)'),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/tweethistory/lib/features/settings/settings_screen.dart
+++ b/tweethistory/lib/features/settings/settings_screen.dart
@@ -8,6 +8,10 @@ class SettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final themeMode = ref.watch(themeModeProvider);
+    final platformDark =
+        MediaQuery.of(context).platformBrightness == Brightness.dark;
+    final isDark =
+        themeMode == ThemeMode.dark || (themeMode == ThemeMode.system && platformDark);
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
@@ -17,7 +21,7 @@ class SettingsScreen extends ConsumerWidget {
         children: [
           SwitchListTile(
             title: const Text('Dark Mode'),
-            value: themeMode == ThemeMode.dark,
+            value: isDark,
             onChanged: (val) {
               ref.read(themeModeProvider.notifier).setDarkMode(val);
             },

--- a/tweethistory/lib/main.dart
+++ b/tweethistory/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'features/tweets/tweets_screen.dart';
 import 'features/bin/bin_screen.dart';
 import 'features/settings/settings_screen.dart';
+import 'providers/theme_provider.dart';
 import 'features/tweets/ui/tweets_upload_button.dart';
 import 'providers/initialization_provider.dart';
 
@@ -17,11 +18,22 @@ class MyApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final initialization = ref.watch(initializationProvider);
+    final themeMode = ref.watch(themeModeProvider);
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.deepPurple,
+          brightness: Brightness.light,
+        ),
       ),
+      darkTheme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.deepPurple,
+          brightness: Brightness.dark,
+        ),
+      ),
+      themeMode: themeMode,
       home: initialization.when(
         data: (data) => const MyHomePage(),
         error:

--- a/tweethistory/lib/providers/theme_provider.dart
+++ b/tweethistory/lib/providers/theme_provider.dart
@@ -1,11 +1,36 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class ThemeModeNotifier extends Notifier<ThemeMode> {
-  @override
-  ThemeMode build() => ThemeMode.system;
+  SharedPreferences? _prefs;
 
-  void setDarkMode(bool isDark) => state = isDark ? ThemeMode.dark : ThemeMode.light;
+  @override
+  ThemeMode build() {
+    _load();
+    return ThemeMode.system;
+  }
+
+  Future<void> _load() async {
+    _prefs = await SharedPreferences.getInstance();
+    final index = _prefs!.getInt('themeMode');
+    if (index != null) {
+      state = ThemeMode.values[index];
+    }
+  }
+
+  Future<void> _save(ThemeMode mode) async {
+    final prefs = _prefs ??= await SharedPreferences.getInstance();
+    await prefs.setInt('themeMode', mode.index);
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    await _save(mode);
+    state = mode;
+  }
+
+  Future<void> setDarkMode(bool isDark) =>
+      setThemeMode(isDark ? ThemeMode.dark : ThemeMode.light);
 }
 
 final themeModeProvider = NotifierProvider<ThemeModeNotifier, ThemeMode>(

--- a/tweethistory/lib/providers/theme_provider.dart
+++ b/tweethistory/lib/providers/theme_provider.dart
@@ -1,0 +1,13 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter/material.dart';
+
+class ThemeModeNotifier extends Notifier<ThemeMode> {
+  @override
+  ThemeMode build() => ThemeMode.system;
+
+  void setDarkMode(bool isDark) => state = isDark ? ThemeMode.dark : ThemeMode.light;
+}
+
+final themeModeProvider = NotifierProvider<ThemeModeNotifier, ThemeMode>(
+  ThemeModeNotifier.new,
+);

--- a/tweethistory/pubspec.yaml
+++ b/tweethistory/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   json_annotation: ^4.9.0
   hooks_riverpod: ^2.6.1
   flutter_hooks: ^0.21.2
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add theme provider for dark mode
- connect `ThemeMode` to `MaterialApp`
- expand `SettingsScreen` with dark mode switch

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684baea3651883309f3e0d85214d46db