### PR TITLE
Add more robust parser tests

### DIFF
--- a/tweethistory/test/timezone_utils_test.dart
+++ b/tweethistory/test/timezone_utils_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tweethistory/utils/timezone_utils.dart';
+
+void main() {
+  group('parseTimezoneOffset', () {
+    test('parses positive offsets', () {
+      expect(parseTimezoneOffset('+0900'), const Duration(hours: 9));
+      expect(parseTimezoneOffset('+0530'), const Duration(hours: 5, minutes: 30));
+    });
+
+    test('parses negative offsets', () {
+      expect(parseTimezoneOffset('-0400'), const Duration(hours: -4));
+      expect(
+        parseTimezoneOffset('-0230'),
+        const Duration(hours: -2, minutes: -30),
+      );
+    });
+
+    test('parses zero offset', () {
+      expect(parseTimezoneOffset('+0000'), Duration.zero);
+    });
+
+    test('throws on invalid format', () {
+      expect(() => parseTimezoneOffset('0900'), throwsException);
+    });
+  });
+
+  group('parseTwitterDate', () {
+    test('parses twitter date to UTC', () {
+      final date = parseTwitterDate('Wed Aug 23 16:35:51 +0900 2023');
+      expect(date.toUtc(), DateTime.utc(2023, 8, 23, 7, 35, 51));
+    });
+  });
+}

--- a/tweethistory/test/tweet_file_parser_test.dart
+++ b/tweethistory/test/tweet_file_parser_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tweethistory/features/tweets/data/tweet_file_parser.dart';
+
+void main() {
+  group('extractJsonArray', () {
+    test('trims prefix and semicolon', () {
+      const js = 'window.YTD.tweets.part0 = [1,2,3];';
+      expect(extractJsonArray(js), '[1,2,3]');
+    });
+
+    test('throws when prefix is missing', () {
+      expect(() => extractJsonArray('[1,2,3];'), throwsException);
+    });
+  });
+
+  test('parseTweetsFromJs parses tweet objects', () {
+    const raw =
+        'window.YTD.tweets.part0 = [{"tweet":{"id":"1","full_text":"hello","created_at":"Wed Aug 23 16:35:51 +0000 2023","entities":{"media":[{"media_url_https":"https://example.com/photo.jpg","type":"photo"}]}}}];';
+
+    final tweets = parseTweetsFromJs(raw);
+
+    expect(tweets.length, 1);
+    final tweet = tweets.first;
+    expect(tweet.id, '1');
+    expect(tweet.text, 'hello');
+    expect(tweet.createdAt.toUtc(), DateTime.utc(2023, 8, 23, 16, 35, 51));
+    expect(tweet.media, hasLength(1));
+    final media = tweet.media.first;
+    expect(media.url, 'https://example.com/photo.jpg');
+    expect(media.type, 'photo');
+  });
+
+  test('parseTweetsFromJs throws on invalid json', () {
+    const raw = 'window.YTD.tweets.part0 = invalid;';
+    expect(() => parseTweetsFromJs(raw), throwsException);
+  });
+}


### PR DESCRIPTION
## Summary
- expand timezone parsing tests with zero offset and invalid input
- add additional extractJsonArray and invalid JSON tests for tweet parser

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684bb019e9908330b7ae3ef9aab7dfb7