### PR TITLE
Add tweet sorting feature

### DIFF
--- a/lib/common/my_search_bar.dart
+++ b/lib/common/my_search_bar.dart
@@ -26,17 +26,17 @@ class MySearchBar extends ConsumerWidget {
               ),
             ),
           ),
-          PopupMenuButton<SortOrder>(
-            icon: const Icon(Icons.sort),
-            onSelected: (order) {
-              ref.read(sortOrderProvider.notifier).set(order);
+          IconButton(
+            icon: Icon(
+              order == SortOrder.newestFirst
+                  ? Icons.arrow_downward
+                  : Icons.arrow_upward,
+            ),
+            tooltip: order == SortOrder.newestFirst ? '新しい順' : '古い順',
+            onPressed: () {
+              ref.read(sortOrderProvider.notifier).toggle();
               ref.read(tweetControllerProvider.notifier).refresh();
             },
-            itemBuilder: (context) => const [
-              PopupMenuItem(value: SortOrder.newestFirst, child: Text('新しい順')),
-              PopupMenuItem(value: SortOrder.oldestFirst, child: Text('古い順')),
-            ],
-            tooltip: order == SortOrder.newestFirst ? '新しい順' : '古い順',
           ),
         ],
       ),

--- a/lib/common/my_search_bar.dart
+++ b/lib/common/my_search_bar.dart
@@ -2,22 +2,43 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../providers/search_query_provider.dart';
+import '../providers/sort_order_provider.dart';
+import '../providers/tweet_controller.dart';
 
 class MySearchBar extends ConsumerWidget {
   const MySearchBar({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final order = ref.watch(sortOrderProvider);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
-      child: TextField(
-        onChanged: ref.read(searchQueryProvider.notifier).set,
-        decoration: const InputDecoration(
-          hintText: '検索',
-          prefixIcon: Icon(Icons.search),
-          border: OutlineInputBorder(),
-          isDense: true,
-        ),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              onChanged: ref.read(searchQueryProvider.notifier).set,
+              decoration: const InputDecoration(
+                hintText: '検索',
+                prefixIcon: Icon(Icons.search),
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+            ),
+          ),
+          PopupMenuButton<SortOrder>(
+            icon: const Icon(Icons.sort),
+            onSelected: (order) {
+              ref.read(sortOrderProvider.notifier).set(order);
+              ref.read(tweetControllerProvider.notifier).refresh();
+            },
+            itemBuilder: (context) => const [
+              PopupMenuItem(value: SortOrder.newestFirst, child: Text('新しい順')),
+              PopupMenuItem(value: SortOrder.oldestFirst, child: Text('古い順')),
+            ],
+            tooltip: order == SortOrder.newestFirst ? '新しい順' : '古い順',
+          ),
+        ],
       ),
     );
   }

--- a/lib/providers/sort_order_provider.dart
+++ b/lib/providers/sort_order_provider.dart
@@ -1,0 +1,18 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+enum SortOrder { newestFirst, oldestFirst }
+
+class SortOrderNotifier extends Notifier<SortOrder> {
+  @override
+  SortOrder build() => SortOrder.newestFirst;
+
+  void set(SortOrder order) => state = order;
+
+  void toggle() => state = state == SortOrder.newestFirst
+      ? SortOrder.oldestFirst
+      : SortOrder.newestFirst;
+}
+
+final sortOrderProvider = NotifierProvider<SortOrderNotifier, SortOrder>(
+  SortOrderNotifier.new,
+);

--- a/lib/providers/tweet_controller.dart
+++ b/lib/providers/tweet_controller.dart
@@ -5,6 +5,7 @@ import '../repository/tweet_repository.dart';
 import '../state/tweet_state.dart';
 import 'repository_providers.dart';
 import 'tag_select_controller.dart';
+import 'sort_order_provider.dart';
 
 class TweetController extends Notifier<TweetState> {
   @override
@@ -33,6 +34,8 @@ class TweetController extends Notifier<TweetState> {
     final allTweets = await repository.loadAllTweets();
     final isSelected = tagSelectionState.selected.isNotEmpty;
 
+    final order = ref.read(sortOrderProvider);
+
     var filteredTweets = <Tweet>[];
     var binnedTweets = <Tweet>[];
     for (var tweet in allTweets) {
@@ -45,7 +48,15 @@ class TweetController extends Notifier<TweetState> {
         filteredTweets.add(tweet);
       }
     }
-    state = (TweetState(tweets: filteredTweets, binned: binnedTweets));
+
+    int compare(Tweet a, Tweet b) => order == SortOrder.newestFirst
+        ? b.createdAt.compareTo(a.createdAt)
+        : a.createdAt.compareTo(b.createdAt);
+
+    filteredTweets = [...filteredTweets]..sort(compare);
+    binnedTweets = [...binnedTweets]..sort(compare);
+
+    state = TweetState(tweets: filteredTweets, binned: binnedTweets);
   }
 
   Future<void> addTweets(List<Tweet> tweets) async {


### PR DESCRIPTION
## Summary
- allow sorting tweets via a popup menu
- keep sort state with new `SortOrderNotifier`
- apply sorting on tweets and binned lists
- sorting is now handled inside `TweetController.refresh`

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_684ee7aa58608330af63179b72f7ca86