### PR TITLE
Add like & retweet counts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Flutter Web",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.dart"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,6 @@ This file provides guidelines for working with the TweetHistory repository.
   ```sh
   flutter test
   ```
-
 - Generate `*.freezed.dart` and `*.g.dart` files:
   ```sh
   flutter pub run build_runner build --delete-conflicting-outputs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@ This file provides guidelines for working with the TweetHistory repository.
   flutter test
   ```
 
+- Generate `*.freezed.dart` and `*.g.dart` files:
+  ```sh
+  flutter pub run build_runner build --delete-conflicting-outputs
+  ```
+
 ## Contribution Guidelines
 
 - Keep commit messages concise and descriptive.

--- a/docs/models/tweets.md
+++ b/docs/models/tweets.md
@@ -21,3 +21,6 @@ TweetHistory で扱うツイートデータの基本的なモデルを定義し�
 | type | string | Yes | `'photo'` や `'video'` など |
 
 タグ情報は `Tag` モデルとして別途管理しています。
+
+既存データに `favoriteCount` または `retweetCount` が含まれていない場合は、
+読み込み時に自動で `0` が設定されます。

--- a/docs/models/tweets.md
+++ b/docs/models/tweets.md
@@ -11,6 +11,8 @@ TweetHistory で扱うツイートデータの基本的なモデルを定義し�
 | text | string | Yes | ツイート本文 |
 | createdAt | DateTime | Yes | 投稿日時 |
 | media | List&lt;Media&gt; | No | 添付メディア情報 |
+| favoriteCount | int | Yes | いいね数 |
+| retweetCount | int | Yes | リツイート数 |
 
 ### Media
 | フィールド名 | 型 | 必須 | 説明 |

--- a/lib/models/tweet.dart
+++ b/lib/models/tweet.dart
@@ -12,8 +12,8 @@ abstract class Tweet with _$Tweet {
     required String text,
     required DateTime createdAt,
     @Default([]) List<Media> media,
-    @JsonKey(defaultValue: 0) @Default(0) int favoriteCount,
-    @JsonKey(defaultValue: 0) @Default(0) int retweetCount,
+    @Default(0) int favoriteCount,
+    @Default(0) int retweetCount,
   }) = _Tweet;
 
   factory Tweet.fromJson(Map<String, dynamic> json) => _$TweetFromJson(json);

--- a/lib/models/tweet.dart
+++ b/lib/models/tweet.dart
@@ -12,6 +12,8 @@ abstract class Tweet with _$Tweet {
     required String text,
     required DateTime createdAt,
     @Default([]) List<Media> media,
+    @JsonKey(defaultValue: 0) @Default(0) int favoriteCount,
+    @JsonKey(defaultValue: 0) @Default(0) int retweetCount,
   }) = _Tweet;
 
   factory Tweet.fromJson(Map<String, dynamic> json) => _$TweetFromJson(json);
@@ -23,13 +25,24 @@ abstract class Tweet with _$Tweet {
     final text = tweet['full_text'] as String;
     final createdAt = parseTwitterDate(tweet['created_at'] as String);
 
-    final mediaJson = tweet['entities']?['media'] as List?;
-    final media =
-        mediaJson != null
-            ? mediaJson.map((m) => Media.fromRawJson(m)).toList()
-            : <Media>[];
+    final favoriteCount =
+        int.tryParse(tweet['favorite_count']?.toString() ?? '0') ?? 0;
+    final retweetCount =
+        int.tryParse(tweet['retweet_count']?.toString() ?? '0') ?? 0;
 
-    return Tweet(id: id, text: text, createdAt: createdAt, media: media);
+    final mediaJson = tweet['entities']?['media'] as List?;
+    final media = mediaJson != null
+        ? mediaJson.map((m) => Media.fromRawJson(m)).toList()
+        : <Media>[];
+
+    return Tweet(
+      id: id,
+      text: text,
+      createdAt: createdAt,
+      media: media,
+      favoriteCount: favoriteCount,
+      retweetCount: retweetCount,
+    );
   }
 }
 

--- a/lib/models/tweet.freezed.dart
+++ b/lib/models/tweet.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Tweet {
 
- String get id; String get text; DateTime get createdAt; List<Media> get media;
+ String get id; String get text; DateTime get createdAt; List<Media> get media;@JsonKey(defaultValue: 0) int get favoriteCount;@JsonKey(defaultValue: 0) int get retweetCount;
 /// Create a copy of Tweet
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $TweetCopyWith<Tweet> get copyWith => _$TweetCopyWithImpl<Tweet>(this as Tweet, 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Tweet&&(identical(other.id, id) || other.id == id)&&(identical(other.text, text) || other.text == text)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other.media, media));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Tweet&&(identical(other.id, id) || other.id == id)&&(identical(other.text, text) || other.text == text)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other.media, media)&&(identical(other.favoriteCount, favoriteCount) || other.favoriteCount == favoriteCount)&&(identical(other.retweetCount, retweetCount) || other.retweetCount == retweetCount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,text,createdAt,const DeepCollectionEquality().hash(media));
+int get hashCode => Object.hash(runtimeType,id,text,createdAt,const DeepCollectionEquality().hash(media),favoriteCount,retweetCount);
 
 @override
 String toString() {
-  return 'Tweet(id: $id, text: $text, createdAt: $createdAt, media: $media)';
+  return 'Tweet(id: $id, text: $text, createdAt: $createdAt, media: $media, favoriteCount: $favoriteCount, retweetCount: $retweetCount)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $TweetCopyWith<$Res>  {
   factory $TweetCopyWith(Tweet value, $Res Function(Tweet) _then) = _$TweetCopyWithImpl;
 @useResult
 $Res call({
- String id, String text, DateTime createdAt, List<Media> media
+ String id, String text, DateTime createdAt, List<Media> media,@JsonKey(defaultValue: 0) int favoriteCount,@JsonKey(defaultValue: 0) int retweetCount
 });
 
 
@@ -66,13 +66,15 @@ class _$TweetCopyWithImpl<$Res>
 
 /// Create a copy of Tweet
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? text = null,Object? createdAt = null,Object? media = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? text = null,Object? createdAt = null,Object? media = null,Object? favoriteCount = null,Object? retweetCount = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,media: null == media ? _self.media : media // ignore: cast_nullable_to_non_nullable
-as List<Media>,
+as List<Media>,favoriteCount: null == favoriteCount ? _self.favoriteCount : favoriteCount // ignore: cast_nullable_to_non_nullable
+as int,retweetCount: null == retweetCount ? _self.retweetCount : retweetCount // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 
@@ -83,7 +85,7 @@ as List<Media>,
 @JsonSerializable()
 
 class _Tweet implements Tweet {
-  const _Tweet({required this.id, required this.text, required this.createdAt, final  List<Media> media = const []}): _media = media;
+  const _Tweet({required this.id, required this.text, required this.createdAt, final  List<Media> media = const [], @JsonKey(defaultValue: 0) this.favoriteCount = 0, @JsonKey(defaultValue: 0) this.retweetCount = 0}): _media = media;
   factory _Tweet.fromJson(Map<String, dynamic> json) => _$TweetFromJson(json);
 
 @override final  String id;
@@ -96,6 +98,8 @@ class _Tweet implements Tweet {
   return EqualUnmodifiableListView(_media);
 }
 
+@override@JsonKey(defaultValue: 0) final  int favoriteCount;
+@override@JsonKey(defaultValue: 0) final  int retweetCount;
 
 /// Create a copy of Tweet
 /// with the given fields replaced by the non-null parameter values.
@@ -110,16 +114,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Tweet&&(identical(other.id, id) || other.id == id)&&(identical(other.text, text) || other.text == text)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other._media, _media));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Tweet&&(identical(other.id, id) || other.id == id)&&(identical(other.text, text) || other.text == text)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other._media, _media)&&(identical(other.favoriteCount, favoriteCount) || other.favoriteCount == favoriteCount)&&(identical(other.retweetCount, retweetCount) || other.retweetCount == retweetCount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,text,createdAt,const DeepCollectionEquality().hash(_media));
+int get hashCode => Object.hash(runtimeType,id,text,createdAt,const DeepCollectionEquality().hash(_media),favoriteCount,retweetCount);
 
 @override
 String toString() {
-  return 'Tweet(id: $id, text: $text, createdAt: $createdAt, media: $media)';
+  return 'Tweet(id: $id, text: $text, createdAt: $createdAt, media: $media, favoriteCount: $favoriteCount, retweetCount: $retweetCount)';
 }
 
 
@@ -130,7 +134,7 @@ abstract mixin class _$TweetCopyWith<$Res> implements $TweetCopyWith<$Res> {
   factory _$TweetCopyWith(_Tweet value, $Res Function(_Tweet) _then) = __$TweetCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String text, DateTime createdAt, List<Media> media
+ String id, String text, DateTime createdAt, List<Media> media,@JsonKey(defaultValue: 0) int favoriteCount,@JsonKey(defaultValue: 0) int retweetCount
 });
 
 
@@ -147,13 +151,15 @@ class __$TweetCopyWithImpl<$Res>
 
 /// Create a copy of Tweet
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? text = null,Object? createdAt = null,Object? media = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? text = null,Object? createdAt = null,Object? media = null,Object? favoriteCount = null,Object? retweetCount = null,}) {
   return _then(_Tweet(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,media: null == media ? _self._media : media // ignore: cast_nullable_to_non_nullable
-as List<Media>,
+as List<Media>,favoriteCount: null == favoriteCount ? _self.favoriteCount : favoriteCount // ignore: cast_nullable_to_non_nullable
+as int,retweetCount: null == retweetCount ? _self.retweetCount : retweetCount // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 

--- a/lib/models/tweet.freezed.dart
+++ b/lib/models/tweet.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Tweet {
 
- String get id; String get text; DateTime get createdAt; List<Media> get media;@JsonKey(defaultValue: 0) int get favoriteCount;@JsonKey(defaultValue: 0) int get retweetCount;
+ String get id; String get text; DateTime get createdAt; List<Media> get media; int get favoriteCount; int get retweetCount;
 /// Create a copy of Tweet
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -49,7 +49,7 @@ abstract mixin class $TweetCopyWith<$Res>  {
   factory $TweetCopyWith(Tweet value, $Res Function(Tweet) _then) = _$TweetCopyWithImpl;
 @useResult
 $Res call({
- String id, String text, DateTime createdAt, List<Media> media,@JsonKey(defaultValue: 0) int favoriteCount,@JsonKey(defaultValue: 0) int retweetCount
+ String id, String text, DateTime createdAt, List<Media> media, int favoriteCount, int retweetCount
 });
 
 
@@ -85,7 +85,7 @@ as int,
 @JsonSerializable()
 
 class _Tweet implements Tweet {
-  const _Tweet({required this.id, required this.text, required this.createdAt, final  List<Media> media = const [], @JsonKey(defaultValue: 0) this.favoriteCount = 0, @JsonKey(defaultValue: 0) this.retweetCount = 0}): _media = media;
+  const _Tweet({required this.id, required this.text, required this.createdAt, final  List<Media> media = const [], this.favoriteCount = 0, this.retweetCount = 0}): _media = media;
   factory _Tweet.fromJson(Map<String, dynamic> json) => _$TweetFromJson(json);
 
 @override final  String id;
@@ -98,8 +98,8 @@ class _Tweet implements Tweet {
   return EqualUnmodifiableListView(_media);
 }
 
-@override@JsonKey(defaultValue: 0) final  int favoriteCount;
-@override@JsonKey(defaultValue: 0) final  int retweetCount;
+@override@JsonKey() final  int favoriteCount;
+@override@JsonKey() final  int retweetCount;
 
 /// Create a copy of Tweet
 /// with the given fields replaced by the non-null parameter values.
@@ -134,7 +134,7 @@ abstract mixin class _$TweetCopyWith<$Res> implements $TweetCopyWith<$Res> {
   factory _$TweetCopyWith(_Tweet value, $Res Function(_Tweet) _then) = __$TweetCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String text, DateTime createdAt, List<Media> media,@JsonKey(defaultValue: 0) int favoriteCount,@JsonKey(defaultValue: 0) int retweetCount
+ String id, String text, DateTime createdAt, List<Media> media, int favoriteCount, int retweetCount
 });
 
 

--- a/lib/models/tweet.g.dart
+++ b/lib/models/tweet.g.dart
@@ -15,6 +15,8 @@ _Tweet _$TweetFromJson(Map<String, dynamic> json) => _Tweet(
           ?.map((e) => Media.fromJson(e as Map<String, dynamic>))
           .toList() ??
       const [],
+  favoriteCount: (json['favoriteCount'] as num?)?.toInt() ?? 0,
+  retweetCount: (json['retweetCount'] as num?)?.toInt() ?? 0,
 );
 
 Map<String, dynamic> _$TweetToJson(_Tweet instance) => <String, dynamic>{
@@ -22,6 +24,8 @@ Map<String, dynamic> _$TweetToJson(_Tweet instance) => <String, dynamic>{
   'text': instance.text,
   'createdAt': instance.createdAt.toIso8601String(),
   'media': instance.media.map((e) => e.toJson()).toList(),
+  'favoriteCount': instance.favoriteCount,
+  'retweetCount': instance.retweetCount,
 };
 
 _Media _$MediaFromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
## Summary
- extend Tweet model with `favoriteCount` and `retweetCount`
- parse these counts when importing tweets
- document new fields in model docs

## Testing
- `dart format .`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_684f7c389b34833088eb95a4cb3046a9